### PR TITLE
Checkpoint model after first score improvement

### DIFF
--- a/pytorchtools.py
+++ b/pytorchtools.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 
 class EarlyStopping:
-    """Early stops the training if validation loss dosen't improve after a given patience."""
+    """Early stops the training if validation loss doesn't improve after a given patience."""
     def __init__(self, patience=7, verbose=False):
         """
         Args:
@@ -24,6 +24,7 @@ class EarlyStopping:
 
         if self.best_score is None:
             self.best_score = score
+            self.save_checkpoint(val_loss, model)
         elif score < self.best_score:
             self.counter += 1
             print(f'EarlyStopping counter: {self.counter} out of {self.patience}')


### PR DESCRIPTION
To get expected output in cases where validation loss doesn't improve after first epoch.

Example of bug:
`Epoch 1/5 	 loss=140.3084 	 val_loss=118.2384 	 time=105.34s`
`Epoch 2/5 	 loss=120.4707 	 val_loss=120.7402 	 time=109.57s`
`Epoch 3/5 	 loss=109.6317 	 val_loss=141.4568 	 time=106.43s`

No way to restore model to state at first epoch.