### PR TITLE
add a custom trace print function to earlEarlyStopping class

### DIFF
--- a/pytorchtools.py
+++ b/pytorchtools.py
@@ -3,7 +3,7 @@ import torch
 
 class EarlyStopping:
     """Early stops the training if validation loss doesn't improve after a given patience."""
-    def __init__(self, patience=7, verbose=False, delta=0, path='checkpoint.pt'):
+    def __init__(self, patience=7, verbose=False, delta=0, path='checkpoint.pt', trace_func=print):
         """
         Args:
             patience (int): How long to wait after last time validation loss improved.
@@ -14,6 +14,8 @@ class EarlyStopping:
                             Default: 0
             path (str): Path for the checkpoint to be saved to.
                             Default: 'checkpoint.pt'
+            trace_func (function): trace print function.
+                            Default: print            
         """
         self.patience = patience
         self.verbose = verbose
@@ -23,7 +25,7 @@ class EarlyStopping:
         self.val_loss_min = np.Inf
         self.delta = delta
         self.path = path
-
+        self.trace_func = trace_func
     def __call__(self, val_loss, model):
 
         score = -val_loss
@@ -33,7 +35,7 @@ class EarlyStopping:
             self.save_checkpoint(val_loss, model)
         elif score < self.best_score + self.delta:
             self.counter += 1
-            print(f'EarlyStopping counter: {self.counter} out of {self.patience}')
+            self.trace_func(f'EarlyStopping counter: {self.counter} out of {self.patience}')
             if self.counter >= self.patience:
                 self.early_stop = True
         else:
@@ -44,6 +46,6 @@ class EarlyStopping:
     def save_checkpoint(self, val_loss, model):
         '''Saves model when validation loss decrease.'''
         if self.verbose:
-            print(f'Validation loss decreased ({self.val_loss_min:.6f} --> {val_loss:.6f}).  Saving model ...')
+            self.trace_func(f'Validation loss decreased ({self.val_loss_min:.6f} --> {val_loss:.6f}).  Saving model ...')
         torch.save(model.state_dict(), self.path)
         self.val_loss_min = val_loss


### PR DESCRIPTION
Hello,

How about adding a custom tracing function argument 'trace_func'  that defaults to print instead of using print? Will help integrate the early stopping more smoothly to larger projects.

Thanks,