### PR TITLE
check if model is instance of DataParallel before saving checkpoint

### DIFF
--- a/pytorchtools.py
+++ b/pytorchtools.py
@@ -26,6 +26,7 @@ class EarlyStopping:
         self.delta = delta
         self.path = path
         self.trace_func = trace_func
+
     def __call__(self, val_loss, model):
 
         score = -val_loss
@@ -47,5 +48,10 @@ class EarlyStopping:
         '''Saves model when validation loss decrease.'''
         if self.verbose:
             self.trace_func(f'Validation loss decreased ({self.val_loss_min:.6f} --> {val_loss:.6f}).  Saving model ...')
-        torch.save(model.state_dict(), self.path)
+        
+        if isinstance(model, torch.nn.DataParallel):
+            torch.save(model.module.state_dict(), self.path)
+        else:
+            torch.save(model.state_dict(), self.path)
+        
         self.val_loss_min = val_loss


### PR DESCRIPTION
## Problem
In current [save_checkpoint](https://github.com/Bjarten/early-stopping-pytorch/blob/f1a4cad7ebe762c1e3ca9e74c0845a555616952b/pytorchtools.py#L46) function, if the model is on multiple GPUs, i.e. model is a instance of [torch.nn.DataParallel](https://pytorch.org/docs/stable/generated/torch.nn.DataParallel.html), and then the saved checkpoint could not be loaded again.

## Describe your changes
Follow the [pytorch tutorial](https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-torch-nn-dataparallel-models), first the current model is checked, if it is a instance of DataParallel class.
If the model is a instance of DataParallel class, then `model.module.state_dict()` is saved instead of `model.state_dict()` in current implementation.



