### PR TITLE
ci: add PR title linting workflow

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,39 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Uncomment the following lines if you want to enforce scopes
+          # scopes: |
+          #   core
+          #   ui
+          # requireScope: true


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to lint Pull Request titles. The workflow ensures that all PR titles follow the Conventional Commits specification, which will improve our changelog generation and semantic versioning process.

## Changes
- Add a new GitHub Actions workflow file: `.github/workflows/pr-title-lint.yml`
- Configure the workflow to run on PR creation, edit, and synchronization
- Use the `amannn/action-semantic-pull-request` action to validate PR titles

## Why
- Enforces consistent and meaningful PR titles
- Facilitates automated versioning and changelog generation
- Improves clarity and communication in our development process

## Additional Notes
- This change does not affect the existing codebase or functionality