### PR TITLE
fix: manual release and publish workflows with version updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Publish Python Package
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:  # Manual trigger
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
           commit: true
           push: true
           tag: true
+          version: true 


### PR DESCRIPTION
## Description
This PR updates both the release and publish workflows to:
1. Ensure proper version updating across all package files
2. Use manual triggers for better control and reliability

## Changes

### Release Workflow Updates
- Added `version: true` parameter to semantic-release action
  - This ensures updates to both `__init__.py` and `pyproject.toml` versions
- Kept explicit tag and push parameters for clarity
- Maintained all necessary permissions

### Publish Workflow Updates
- Changed from tag-based trigger to manual `workflow_dispatch`
- Simplified workflow control and verification process
- Maintained all PyPI trusted publisher configurations

## Process After Changes
1. Manual trigger of "Create New Release" workflow:
   - Updates versions in package files
   - Creates new tag and GitHub release
2. Manual trigger of "Publish Python Package" workflow:
   - Builds package with updated versions
   - Publishes to PyPI
