### PR TITLE
fix: semantic release version updating pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
           commit: true
           push: true
           tag: true
-          version: true 
+          version: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "early-stopping-pytorch"
-version = "1.0.2"
+version = "1.0.1"
 description = "A PyTorch utility package for Early Stopping"
 readme = "README.md"
 authors = [
@@ -17,8 +17,8 @@ dependencies = [
 ]
 
 [tool.semantic_release]
-version_variable = ["early_stopping_pytorch/__init__.py:__version__"]
-version_toml = ["pyproject.toml:project.version"]  # Add this line
+version_variable = ["early_stopping_pytorch/__init__.py:__version__ = \"{version}\""]
+version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 upload_to_pypi = false
 build_command = "pip install build && python -m build"


### PR DESCRIPTION
## Description
This PR fixes the version updating in `__init__.py` by making the version pattern more explicit in semantic-release configuration.

## Issue
While `pyproject.toml` version is being updated correctly during release, the version in `__init__.py` remains unchanged. This is due to semantic-release needing a more explicit pattern to find and replace the version string.

## Changes
Updated in pyproject.toml:
```toml
[tool.semantic_release]
# Old
# version_variable = ["early_stopping_pytorch/__init__.py:__version__"]

# New - explicit pattern
version_variable = ["early_stopping_pytorch/__init__.py:__version__ = \"{version}\""]