### PR TITLE
fix: correct version regex in semantic release config for version updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "early-stopping-pytorch"
-version = "1.0.3"
+version = "1.0.1"
 description = "A PyTorch utility package for Early Stopping"
 readme = "README.md"
 authors = [
@@ -17,8 +17,8 @@ dependencies = [
 ]
 
 [tool.semantic_release]
-version_variable = ["early_stopping_pytorch/__init__.py:__version__ = \"{version}\""]
-version_toml = ["pyproject.toml:project.version"]
+version_variable = ["early_stopping_pytorch/__init__.py:^__version__ = \"(.*)\""]
+version_toml = ["pyproject.toml:project.version"]  # Add this line
 branch = "main"
 upload_to_pypi = false
 build_command = "pip install build && python -m build"


### PR DESCRIPTION
### Overview

This PR fixes an issue with `python-semantic-release` where the version in `__init__.py` was not updated during releases due to an incorrect `version_variable` configuration in `pyproject.toml`.

### Changes Made

1. **Updated `version_variable` in `pyproject.toml`**:
   - Changed the `version_variable` setting to use an explicit regex pattern: `early_stopping_pytorch/__init__.py:^__version__ = "(.*)"`.
   - This pattern directly matches the format of the version string in `__init__.py`, allowing `python-semantic-release` to locate and update it successfully.