### PR TITLE
fix: correct versioning for __version__ in __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "early-stopping-pytorch"
-version = "1.0.6"
+version = "1.0.5"
 description = "A PyTorch utility package for Early Stopping"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "early-stopping-pytorch"
-version = "1.0.5"
+version = "1.0.6"
 description = "A PyTorch utility package for Early Stopping"
 readme = "README.md"
 authors = [
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [tool.semantic_release]
-version_variable = "early_stopping_pytorch/__init__.py:__version__"
+version_variables = ["early_stopping_pytorch/__init__.py:__version__"]
 tag_format = "v{version}"
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "early-stopping-pytorch"
-version = "1.0.6"
+version = "1.0.5"
 description = "A PyTorch utility package for Early Stopping"
 readme = "README.md"
 authors = [
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [tool.semantic_release]
-version_variables = ["early_stopping_pytorch/__init__.py:__version__"]
+version_variable = "early_stopping_pytorch/__init__.py:__version__"
 tag_format = "v{version}"
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"


### PR DESCRIPTION
**Description**:  
This PR updates the `pyproject.toml` configuration to ensure that `python-semantic-release` correctly updates the `__version__` variable in `early_stopping_pytorch/__init__.py`.

### Changes:
- **config**: Replaced `version_variable` with `version_variables`.
- Set `version_variables = ["early_stopping_pytorch/__init__.py:__version__"]` to specify the correct file and variable for version bumping.

This fix aligns the configuration with `python-semantic-release` requirements and should resolve the versioning update issue in `early_stopping_pytorch/__init__.py`.