### PR TITLE
fix: simplify build configuration and update citation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ If you find this package useful in your research, please consider citing it as:
   title = {early-stopping-pytorch: A PyTorch utility package for Early Stopping},
   year = {2024},
   url = {https://github.com/Bjarten/early-stopping-pytorch},
-  note = {Version 1.0.7}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,18 +16,8 @@ dependencies = [
     "torch>=1.9.0"
 ]
 
-[project.urls]
-Repository = "https://github.com/Bjarten/early-stopping-pytorch"
-
 [tool.semantic_release]
-version_variables = [
-    "early_stopping_pytorch/__init__.py:__version__",
-    "README.md:version_note"
-]
-version_pattern = '''
-    (?P<variable>__version__\s*=\s*['"](?P<version>[^'"]+)['"]) |
-    (?P<variable>note\s*=\s*\{Version\s(?P<version>[^}]+)\})
-'''
+version_variables = ["early_stopping_pytorch/__init__.py:__version__"]
 tag_format = "v{version}"
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "torch>=1.9.0"
 ]
 
+[project.urls]
+Repository = "https://github.com/Bjarten/early-stopping-pytorch"
+
 [tool.semantic_release]
 version_variables = ["early_stopping_pytorch/__init__.py:__version__"]
 tag_format = "v{version}"


### PR DESCRIPTION
This PR simplifies the `pyproject.toml` configuration and streamlines the citation format for `early-stopping-pytorch`.

- **citation update**: Removed the version note from the `bibtex` citation

```bibtex
@misc{early_stopping_pytorch,
  author = {Bjarte Sunde},
  title = {early-stopping-pytorch: A PyTorch utility package for Early Stopping},
  year = {2024},
  url = {https://github.com/Bjarten/early-stopping-pytorch},
}
